### PR TITLE
Enabling SQLA engine params from meltano.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # target-mssql
 
-`target-mssql` is a Singer target for mssql. !!! Warning !!! really early version.  It works barely.
+`target-mssql` is a Singer target for mssql. !!! Warning !!! really early version.  It works ok 😐.  This target can accept Meltano Batch Messages.  Not doing naitve bcp loads yet.
 
 Built with the [Meltano Target SDK](https://sdk.meltano.com).
 
@@ -52,6 +52,7 @@ target-mssql --about --format=markdown
 | user                | False    | None    | The User Account who has been granted access to the SQL Server |
 | password            | False    | None    | The Password for the User account |
 | database            | False    | None    | The Default database for this connection |
+| sqlalchemy_eng_params| False    | None    | SQLAlchemy Engine Paramaters: fast_executemany, future |
 | sqlalchemy_url_query| False    | None    | SQLAlchemy URL Query options: driver, TrustServerCertificate |
 | batch_config        | False    | None    | Optional Batch Message configuration |
 | start_date          | False    | None    | The earliest record date to sync |

--- a/target_mssql/target.py
+++ b/target_mssql/target.py
@@ -51,6 +51,22 @@ class Targetmssql(SQLTarget):
             description="The Default database for this connection"
         ),
         th.Property(
+            "sqlalchemy_eng_params",
+            th.ObjectType(
+                th.Property(
+                "fast_executemany",
+                th.StringType,
+                description="Fast Executemany Mode: True, False"
+                ),
+                th.Property(
+                "future",
+                th.StringType,
+                description="Run the engine in 2.0 mode: True, False"
+                )
+            ),
+            description="SQLAlchemy Engine Paramaters: fast_executemany, future"
+        ),
+        th.Property(
             "sqlalchemy_url_query",
             th.ObjectType(
                 th.Property(


### PR DESCRIPTION
Closes #3 a feature request to allow SQLAlchemy parameters to be set in the` meltano.yml`. `fast_executemany` and `future` currently supported. This can be extended upon request